### PR TITLE
PDF information with hyperref

### DIFF
--- a/menukeys.dtx
+++ b/menukeys.dtx
@@ -34,6 +34,15 @@
    urlcolor=darkred,
    bookmarksopen=true,
    bookmarksdepth=10,
+   pdftitle={The menukeys package},
+   pdfsubject={%
+     Format menu sequences, paths and keystrokes from lists.%
+   },
+   pdfauthor={%
+     Tobias Weh (mail@tobiw@de), Jonathan P. Spratte
+     (jspratte@yahoo.de)%
+   },
+   pdfkeywords={The menukeys package, LaTeX}
 }{hyperref}
 \PassOptionsToPackage{hyphens}{url}
 \usepackage{hypdoc}


### PR DESCRIPTION
Currently the documentation PDF shows weird information as it is directly imported from the TeX-code. It can be seen in the following screenshots.

* See the title of the PDF file when opened from a PDF viewer.
  
  ![Screenshot_2021-09-11_13-44-46](https://user-images.githubusercontent.com/54938729/132941387-feca79c4-b633-4913-9de5-4d732e9eee5c.png)

* See the header of the webpage when opened from the CTAN documentation link.

  ![Screenshot_2021-09-10_21-43-53](https://user-images.githubusercontent.com/54938729/132941277-a4f79784-957f-4622-af7d-378ff648edc4.png)

* See the PDF information when opened from a PDF viewer.

  ![Screenshot_2021-09-10_21-39-37](https://user-images.githubusercontent.com/54938729/132941343-82b05a20-c566-4c53-8257-c40c46066976.png)

Now compare this with the following.

![Screenshot_2021-09-10_21-43-16](https://user-images.githubusercontent.com/54938729/132941421-baca5f6d-5cc4-474b-a17b-568a78e8e7c3.png)

![Screenshot_2021-09-10_21-42-56](https://user-images.githubusercontent.com/54938729/132941427-76f2c55a-e4bb-4150-ac57-926d1f2899bd.png)

IMO this is much better and informative than the previous one.