### PR TITLE
Make `\hspace`s after `shadowedroundedkeys` and `shadowedangularkeys` unbreakable

### DIFF
--- a/menukeys.dtx
+++ b/menukeys.dtx
@@ -1439,7 +1439,7 @@
    \hspace{0.2ex}\hspace{0.1em plus 0.1em minus 0.05em}%
    \textcolor{\usemenucolor{b}}{\raisebox{0.25ex}{\sffamily\relsize{-2}+}}%
    \hspace{0.1em plus 0.1em minus 0.05em}%
-][\hspace{0.2ex}]{gray}
+][\kern0.2ex]{gray}
 
 \tikzset{tw@angularkeys@base/.style={%
    tw@set@tikz@colors,
@@ -1481,7 +1481,7 @@
    \hspace{0.2ex}\hspace{0.1em plus 0.1em minus 0.05em}%
    \textcolor{\usemenucolor{b}}{\raisebox{0.25ex}{\sffamily\relsize{-2}+}}%
    \hspace{0.1em plus 0.1em minus 0.05em}%
-][\hspace{0.2ex}]{gray}
+][\kern0.2ex]{gray}
 
 \tikzset{tw@typewriterkeys@base/.style={%
    tw@set@tikz@colors,


### PR DESCRIPTION
Hello,

Both `shadowedroundedkeys` and `shadowedangularkeys` key styles insert a `\hspace{0.2ex}` after the last key.

However, if the key is directly followed by punctuation, this space should be unbreakable so that the punctuation does not wrap to the next line.

See, e.g.:
```tex
\documentclass[a4paper]{article}
\usepackage{menukeys}
\renewmenumacro{\keys}{shadowedroundedkeys}
\begin{document}
\noindent Lorem ipsum dolor sit amet, consectetur adipiscing elitus,
sed do eiusmod \keys{Ctrl}, incididunt ut labore et dolore magna aliqua.
\end{document}
```
which currently produces:
![shadowedroundedkeys](https://user-images.githubusercontent.com/79416808/175656888-570040cb-ac94-4881-a779-b4924da23fa0.png)

As proposed in this PR, adding a `\nobreak` before the `\hspace` prevents this, and the line doesn't wrap just before the comma.

Thank you!

snipfoo