### PR TITLE
Documentation Clarification

### DIFF
--- a/menukeys.dtx
+++ b/menukeys.dtx
@@ -438,6 +438,12 @@
 % \menukeys defines several ``styles'' that determine the output format
 % of a menu macro. There are some predefined styles and others can be
 % created by the user.
+% 
+% Both pre-defined and custom styles may be applied using the command 
+% |\renewmenumacro|\marg{macro}\oarg{input sep}\marg{style}. For further 
+% information on defining and using macro styles, refer to section~\ref{menumacros}.
+% For example, the ``shadowed angular'' keys style may be applied using the command
+% |\renewmenumacro|\hspace{0pt}|{\keys}|\hspace{0pt}|{shadowedangularkeys}|.
 % \subsubsection{Predefined styles}
 % 
 % \teststyle{menus}{File,Extras,Preferences}{Menu}


### PR DESCRIPTION
Add a paragraph to "Subsection 4.2: Styles" clarifying how to apply styles.

I ran into the same difficulty as in [Issue #46](https://github.com/tweh/menukeys/issues/46), and this seems like a reasonable solution. I am aware that this is also documented in the third paragraph of Sub-subsection 4.4.2, but that seems rather deeply buried in the documentation for a feature that will be used as often as selecting a style. It seems odd that the predefined styles are given a whole subsection covering several pages, but the information on how to apply these styles is several pages later and a level deeper.